### PR TITLE
feat(tcp): add getter methods for TCP socket metrics

### DIFF
--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -683,6 +683,50 @@ impl<'a> Socket<'a> {
         self.nagle
     }
 
+    pub fn remote_mss(&self) -> usize {
+        self.remote_mss
+    }
+
+    pub fn remote_win_len(&self) -> usize {
+        self.remote_win_len
+    }
+
+    pub fn remote_win_scale(&self) -> Option<u8> {
+        self.remote_win_scale
+    }
+
+    pub fn rtt(&self) -> u32 {
+        self.rtte.rtt
+    }
+
+    pub fn rtt_var(&self) -> u32 {
+        self.rtte.deviation
+    }
+
+    pub fn rto(&self) -> Duration {
+        self.rtte.retransmission_timeout()
+    }
+
+    pub fn retransmits(&self) -> u8 {
+        self.rtte.rto_count
+    }
+
+    pub fn cwnd(&self) -> usize {
+        self.congestion_controller.cwnd()
+    }
+
+    pub fn ssthresh(&self) -> usize {
+        self.congestion_controller.ssthresh()
+    }
+
+    pub fn local_seq_no(&self) -> TcpSeqNumber {
+        self.local_seq_no
+    }
+
+    pub fn remote_last_ack(&self) -> Option<TcpSeqNumber> {
+        self.remote_last_ack
+    }
+
     /// Return the current window field value, including scaling according to RFC 1323.
     ///
     /// Used in internal calculations as well as packet generation.

--- a/src/socket/tcp/congestion.rs
+++ b/src/socket/tcp/congestion.rs
@@ -30,6 +30,12 @@ pub(super) trait Controller {
 
     /// Set the maximum segment size.
     fn set_mss(&mut self, mss: usize) {}
+
+    /// Returns the current congestion window size.
+    fn cwnd(&self) -> usize;
+
+    /// Returns the current slow start threshold.
+    fn ssthresh(&self) -> usize;
 }
 
 #[derive(Debug)]
@@ -71,6 +77,16 @@ impl AnyController {
         }
 
         AnyController::None(no_control::NoControl)
+    }
+
+    #[inline]
+    pub fn cwnd(&self) -> usize {
+        self.inner().cwnd()
+    }
+
+    #[inline]
+    pub fn ssthresh(&self) -> usize {
+        self.inner().ssthresh()
     }
 
     #[inline]

--- a/src/socket/tcp/congestion/cubic.rs
+++ b/src/socket/tcp/congestion/cubic.rs
@@ -38,6 +38,14 @@ impl Controller for Cubic {
         self.cwnd
     }
 
+    fn cwnd(&self) -> usize {
+        self.cwnd
+    }
+
+    fn ssthresh(&self) -> usize {
+        self.ssthresh
+    }
+
     fn on_retransmit(&mut self, now: Instant) {
         self.w_max = self.cwnd;
         self.ssthresh = self.cwnd >> 1;

--- a/src/socket/tcp/congestion/no_control.rs
+++ b/src/socket/tcp/congestion/no_control.rs
@@ -8,4 +8,12 @@ impl Controller for NoControl {
     fn window(&self) -> usize {
         usize::MAX
     }
+
+    fn cwnd(&self) -> usize {
+        0
+    }
+
+    fn ssthresh(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/socket/tcp/congestion/reno.rs
+++ b/src/socket/tcp/congestion/reno.rs
@@ -47,6 +47,14 @@ impl Controller for Reno {
         self.ssthresh = (self.cwnd >> 1).max(self.min_cwnd);
     }
 
+    fn cwnd(&self) -> usize {
+        self.cwnd
+    }
+
+    fn ssthresh(&self) -> usize {
+        self.ssthresh
+    }
+
     fn on_retransmit(&mut self, _now: Instant) {
         self.cwnd = (self.cwnd >> 1).max(self.min_cwnd);
     }


### PR DESCRIPTION
- Add remote_mss, remote_win_len, remote_win_scale getters
- Add rtt, rtt_var, rto, retransmits getters
- Add cwnd, ssthresh getters via congestion controller trait
- Add local_seq_no, remote_last_ack getters
- Implement cwnd and ssthresh for Cubic, Reno, and NoControl controllers